### PR TITLE
Add skeletal listdebtors feature

### DIFF
--- a/src/main/java/paymelah/logic/commands/ListDebtorsCommand.java
+++ b/src/main/java/paymelah/logic/commands/ListDebtorsCommand.java
@@ -1,0 +1,24 @@
+package paymelah.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static paymelah.model.Model.PREDICATE_SHOW_FRIENDS; //placeholder for predicate that shows debtors
+
+import paymelah.model.Model;
+
+/**
+ * Lists all persons with debts in the address book to the user.
+ */
+public class ListDebtorsCommand extends Command {
+
+    public static final String COMMAND_WORD = "listdebtors";
+
+    public static final String MESSAGE_SUCCESS = "Listed all persons with debts";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_FRIENDS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/paymelah/logic/parser/AddressBookParser.java
+++ b/src/main/java/paymelah/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import paymelah.logic.commands.ExitCommand;
 import paymelah.logic.commands.FindCommand;
 import paymelah.logic.commands.HelpCommand;
 import paymelah.logic.commands.ListCommand;
+import paymelah.logic.commands.ListDebtorsCommand;
 import paymelah.logic.parser.exceptions.ParseException;
 
 /**
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case ListDebtorsCommand.COMMAND_WORD:
+            return new ListDebtorsCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/paymelah/model/Model.java
+++ b/src/main/java/paymelah/model/Model.java
@@ -5,7 +5,9 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import paymelah.commons.core.GuiSettings;
+import paymelah.model.person.Name;
 import paymelah.model.person.Person;
+import paymelah.model.tag.Tag;
 
 /**
  * The API of the Model component.
@@ -13,6 +15,7 @@ import paymelah.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Person> PREDICATE_SHOW_FRIENDS = p -> p.getTags().contains(new Tag("friends"));
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.

--- a/src/test/java/paymelah/logic/commands/ListDebtorsCommandTest.java
+++ b/src/test/java/paymelah/logic/commands/ListDebtorsCommandTest.java
@@ -1,0 +1,31 @@
+package paymelah.logic.commands;
+
+import static paymelah.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static paymelah.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static paymelah.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static paymelah.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import paymelah.model.Model;
+import paymelah.model.ModelManager;
+import paymelah.model.UserPrefs;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListDebtorsCommand.
+ */
+class ListDebtorsCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    //TODO add test cases
+
+}


### PR DESCRIPTION
Add:

- Basic structure for ListDebtorCommand and ListDebtorCommandTest
- Currently filters the list to show Persons with `friends` tag (placeholder)

TODO:
- Implement concrete Predicate to filter by whether Person has Debt
- Add unit tests to ListDebtorCommandTest

Possible Extensions:
- Implement listdebtors with more functionality e.g. (`listdebtors m/20` -> lists Persons who owe more than 20 dollars)