### PR TITLE
Add tests for DeleteDebtCommand and DeleteDebtCommandParser

### DIFF
--- a/src/main/java/paymelah/commons/core/index/Index.java
+++ b/src/main/java/paymelah/commons/core/index/Index.java
@@ -51,4 +51,9 @@ public class Index {
                 || (other instanceof Index // instanceof handles nulls
                 && zeroBasedIndex == ((Index) other).zeroBasedIndex); // state check
     }
+
+    @Override
+    public int hashCode() {
+        return zeroBasedIndex;
+    }
 }

--- a/src/main/java/paymelah/logic/commands/DeleteDebtCommand.java
+++ b/src/main/java/paymelah/logic/commands/DeleteDebtCommand.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static paymelah.logic.parser.CliSyntax.PREFIX_DEBT;
 import static paymelah.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -34,8 +34,9 @@ public class DeleteDebtCommand extends Command {
             + "used in the displayed person list. The debt is specified by the index number "
             + "of the debt displayed in the person's debt field. Multiple debts may be specified.\n"
             + "Parameters: PERSON_INDEX (must be a positive integer) "
-            + PREFIX_DEBT + "DEBT_INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DEBT + "2 " + PREFIX_DEBT + "3";
+            + PREFIX_DEBT + "DEBT_INDEX... (must be a positive integer. multiple indexes must "
+            + "be separated by a space)\n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_DEBT + "2 3";
 
     public static final String MESSAGE_DELETE_DEBT_SUCCESS = "Deleted Debt(s) from: %1$s:\n";
 
@@ -67,7 +68,7 @@ public class DeleteDebtCommand extends Command {
 
         Person debtorToUpdate = lastShownList.get(debtorIndex.getZeroBased());
         List<Debt> initialDebts = debtorToUpdate.getDebts().asList();
-        Set<Debt> debtsToDelete = new HashSet<>();
+        List<Debt> debtsToDelete = new ArrayList<>();
 
         for (Index debtIndex : debtIndexes) {
             requireNonNull(debtIndex);
@@ -104,7 +105,7 @@ public class DeleteDebtCommand extends Command {
      * @param debtsToDelete Set of {@code Debt}s to delete from the {@code debtorToReduce}.
      * @return Person with a reduced {@code DebtList}.
      */
-    private static Person createReducedDebtor(Person debtorToReduce, Set<Debt> debtsToDelete) {
+    private static Person createReducedDebtor(Person debtorToReduce, List<Debt> debtsToDelete) {
         requireNonNull(debtorToReduce);
         requireNonNull(debtsToDelete);
 

--- a/src/main/java/paymelah/logic/parser/DeleteDebtCommandParser.java
+++ b/src/main/java/paymelah/logic/parser/DeleteDebtCommandParser.java
@@ -4,7 +4,10 @@ import static paymelah.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static paymelah.logic.parser.CliSyntax.PREFIX_DEBT;
 import static paymelah.logic.parser.ParserUtil.arePrefixesPresent;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import paymelah.commons.core.index.Index;
 import paymelah.logic.commands.DeleteDebtCommand;
@@ -30,8 +33,10 @@ public class DeleteDebtCommandParser implements Parser<DeleteDebtCommand> {
 
         try {
             Index personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
-            Set<Index> indexList = ParserUtil.parseIndexes(argMultimap.getAllValues(PREFIX_DEBT));
-            return new DeleteDebtCommand(personIndex, indexList);
+            List<String> debtIndexList = Arrays.stream(argMultimap.getValue(PREFIX_DEBT).get().split(" "))
+                    .collect(Collectors.toList());
+            Set<Index> debtIndexSet = ParserUtil.parseIndexes(debtIndexList);
+            return new DeleteDebtCommand(personIndex, debtIndexSet);
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDebtCommand.MESSAGE_USAGE), pe);

--- a/src/test/java/paymelah/logic/commands/CommandTestUtil.java
+++ b/src/test/java/paymelah/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package paymelah.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static paymelah.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static paymelah.logic.parser.CliSyntax.PREFIX_DEBT;
 import static paymelah.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static paymelah.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static paymelah.logic.parser.CliSyntax.PREFIX_MONEY;
@@ -85,6 +86,13 @@ public class CommandTestUtil {
 
     public static final String INVALID_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + " ";
     public static final String INVALID_MONEY_DESC = " " + PREFIX_MONEY + "one hundred";
+
+    public static final String VALID_DEBT_INDEX = " " + PREFIX_DEBT + "1";
+    public static final String VALID_DEBT_INDEXES = " " + PREFIX_DEBT + "1 2 3";
+    public static final String VALID_DEBT_INDEXES_REPEAT = " " + PREFIX_DEBT + "1 3 3 1";
+    public static final String INVALID_DEBT_INDEX = " " + PREFIX_DEBT + "a";
+    public static final String INVALID_DEBT_INDEX_ZERO = " " + PREFIX_DEBT + "0";
+    public static final String INVALID_DEBT_INDEXES = " " + PREFIX_DEBT + "1  2";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
+++ b/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
@@ -2,22 +2,36 @@ package paymelah.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static paymelah.logic.commands.CommandTestUtil.assertCommandFailure;
+import static paymelah.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static paymelah.logic.commands.CommandTestUtil.showDebtors;
+import static paymelah.testutil.TypicalIndexes.INDEX_FIFTH_PERSON;
 import static paymelah.testutil.TypicalIndexes.INDEX_FIRST_DEBT;
 import static paymelah.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static paymelah.testutil.TypicalIndexes.INDEX_SECOND_DEBT;
 import static paymelah.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static paymelah.testutil.TypicalIndexes.INDEX_SEVENTH_PERSON;
 import static paymelah.testutil.TypicalIndexes.INDEX_THIRD_DEBT;
 import static paymelah.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import paymelah.commons.core.Messages;
 import paymelah.commons.core.index.Index;
+import paymelah.model.AddressBook;
 import paymelah.model.Model;
 import paymelah.model.ModelManager;
 import paymelah.model.UserPrefs;
+import paymelah.model.debt.Debt;
+import paymelah.model.debt.DebtList;
+import paymelah.model.person.Person;
+import paymelah.testutil.DebtListBuilder;
+import paymelah.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
@@ -27,8 +41,134 @@ public class DeleteDebtCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    //TODO Add more tests
+    @Test
+    public void execute_validIndexFollowedByValidDebtOnUnfilteredList_success() {
+        Person debtor = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIRST_PERSON, debtIndexSet);
 
+        Debt toDelete = debtor.getDebts().asList().get(INDEX_FIRST_DEBT.getZeroBased());
+        DebtList expectedDebtList = new DebtListBuilder(debtor.getDebts()).build().removeDebt(toDelete);
+        Person editedDebtor = new PersonBuilder(debtor).withDebts(expectedDebtList).build();
+
+        String mainMessage = String.format(DeleteDebtCommand.MESSAGE_DELETE_DEBT_SUCCESS, editedDebtor.getName());
+        StringBuilder expectedMessage = new StringBuilder(mainMessage);
+        expectedMessage.append("1. ").append(toDelete.toString()).append("\n");
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), editedDebtor);
+
+        assertCommandSuccess(deleteDebtCommand, model, expectedMessage.toString(), expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFollowedByValidDebtOnFilteredList_success() {
+        showDebtors(model);
+
+        Person debtor = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIRST_PERSON, debtIndexSet);
+
+        Debt toDelete = debtor.getDebts().asList().get(INDEX_FIRST_DEBT.getZeroBased());
+        DebtList expectedDebtList = new DebtListBuilder(debtor.getDebts()).build().removeDebt(toDelete);
+        Person editedDebtor = new PersonBuilder(debtor).withDebts(expectedDebtList).build();
+
+        String mainMessage = String.format(DeleteDebtCommand.MESSAGE_DELETE_DEBT_SUCCESS, editedDebtor.getName());
+        StringBuilder expectedMessage = new StringBuilder(mainMessage);
+        expectedMessage.append("1. ").append(toDelete.toString()).append("\n");
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()), editedDebtor);
+
+        assertCommandSuccess(deleteDebtCommand, model, expectedMessage.toString(), expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFollowedByValidDebtsOnUnfilteredList_success() {
+        Person debtor = model.getFilteredPersonList().get(INDEX_SEVENTH_PERSON.getZeroBased());
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_SECOND_DEBT, INDEX_FIRST_DEBT));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_SEVENTH_PERSON, debtIndexSet);
+
+        Debt toDeleteOne = debtor.getDebts().asList().get(INDEX_FIRST_DEBT.getZeroBased());
+        Debt toDeleteTwo = debtor.getDebts().asList().get(INDEX_SECOND_DEBT.getZeroBased());
+        DebtList expectedDebtList = new DebtListBuilder(debtor.getDebts()).build()
+                .removeDebt(toDeleteOne).removeDebt(toDeleteTwo);
+        Person editedDebtor = new PersonBuilder(debtor).withDebts(expectedDebtList).build();
+
+        String mainMessage = String.format(DeleteDebtCommand.MESSAGE_DELETE_DEBT_SUCCESS, editedDebtor.getName());
+        StringBuilder expectedMessage = new StringBuilder(mainMessage);
+        expectedMessage.append("1. ").append(toDeleteOne.toString()).append("\n");
+        expectedMessage.append("2. ").append(toDeleteTwo.toString()).append("\n");
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_SEVENTH_PERSON.getZeroBased()), editedDebtor);
+
+        assertCommandSuccess(deleteDebtCommand, model, expectedMessage.toString(), expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFollowedByValidDebtsOnFilteredList_success() {
+        showDebtors(model);
+
+        Person debtor = model.getFilteredPersonList().get(INDEX_FIFTH_PERSON.getZeroBased());
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_SECOND_DEBT, INDEX_FIRST_DEBT));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIFTH_PERSON, debtIndexSet);
+
+        Debt toDeleteOne = debtor.getDebts().asList().get(INDEX_FIRST_DEBT.getZeroBased());
+        Debt toDeleteTwo = debtor.getDebts().asList().get(INDEX_SECOND_DEBT.getZeroBased());
+        DebtList expectedDebtList = new DebtListBuilder(debtor.getDebts()).build()
+                .removeDebt(toDeleteOne).removeDebt(toDeleteTwo);
+        Person editedDebtor = new PersonBuilder(debtor).withDebts(expectedDebtList).build();
+
+        String mainMessage = String.format(DeleteDebtCommand.MESSAGE_DELETE_DEBT_SUCCESS, editedDebtor.getName());
+        StringBuilder expectedMessage = new StringBuilder(mainMessage);
+        expectedMessage.append("1. ").append(toDeleteOne.toString()).append("\n");
+        expectedMessage.append("2. ").append(toDeleteTwo.toString()).append("\n");
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setPerson(model.getFilteredPersonList().get(INDEX_FIFTH_PERSON.getZeroBased()), editedDebtor);
+
+        assertCommandSuccess(deleteDebtCommand, model, expectedMessage.toString(), expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexOnUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(outOfBoundIndex, debtIndexSet);
+        assertCommandFailure(deleteDebtCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_invalidIndexOnFilteredList_throwsCommandException() {
+        showDebtors(model);
+
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(outOfBoundIndex, debtIndexSet);
+        assertCommandFailure(deleteDebtCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFollowedByInvalidDebtOnUnfilteredList_throwsCommandException() {
+        Person debtor = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        int debtCount = debtor.getDebts().asList().size();
+        Set<Index> debtIndexSet = new HashSet<>(List.of(Index.fromZeroBased(debtCount)));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIRST_PERSON, debtIndexSet);
+        assertCommandFailure(deleteDebtCommand, model, Messages.MESSAGE_INVALID_DEBT_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFollowedByInvalidDebtOnFilteredList_throwsCommandException() {
+        showDebtors(model);
+
+        Person debtor = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        int debtCount = debtor.getDebts().asList().size();
+        Set<Index> debtIndexSet = new HashSet<>(List.of(Index.fromZeroBased(debtCount)));
+        DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIRST_PERSON, debtIndexSet);
+        assertCommandFailure(deleteDebtCommand, model, Messages.MESSAGE_INVALID_DEBT_DISPLAYED_INDEX);
+    }
 
     @Test
     public void equals() {

--- a/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
+++ b/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
@@ -109,7 +109,6 @@ public class DeleteDebtCommandTest {
     @Test
     public void execute_validIndexFollowedByValidDebtsOnFilteredList_success() {
         showDebtors(model);
-
         Person debtor = model.getFilteredPersonList().get(INDEX_FIFTH_PERSON.getZeroBased());
         Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_SECOND_DEBT, INDEX_FIRST_DEBT));
         DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIFTH_PERSON, debtIndexSet);

--- a/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
+++ b/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
@@ -41,10 +41,6 @@ public class DeleteDebtCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-<<<<<<< HEAD
-
-=======
->>>>>>> 9b73f9b1146d25c4ff36bc99f9cea7956389111d
     @Test
     public void execute_validIndexFollowedByValidDebtOnUnfilteredList_success() {
         Person debtor = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -113,10 +109,7 @@ public class DeleteDebtCommandTest {
     @Test
     public void execute_validIndexFollowedByValidDebtsOnFilteredList_success() {
         showDebtors(model);
-<<<<<<< HEAD
-=======
-        
->>>>>>> 9b73f9b1146d25c4ff36bc99f9cea7956389111d
+
         Person debtor = model.getFilteredPersonList().get(INDEX_FIFTH_PERSON.getZeroBased());
         Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_SECOND_DEBT, INDEX_FIRST_DEBT));
         DeleteDebtCommand deleteDebtCommand = new DeleteDebtCommand(INDEX_FIFTH_PERSON, debtIndexSet);
@@ -209,5 +202,4 @@ public class DeleteDebtCommandTest {
         // different set of Debts -> returns false
         assertFalse(deleteDebtFirstCommand.equals(deleteDebtThirdCommand));
     }
-
 }

--- a/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
+++ b/src/test/java/paymelah/logic/commands/DeleteDebtCommandTest.java
@@ -35,7 +35,7 @@ import paymelah.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code ClearDebtsCommand}.
+ * {@code DeleteDebtCommand}.
  */
 public class DeleteDebtCommandTest {
 

--- a/src/test/java/paymelah/logic/parser/DeleteDebtCommandParserTest.java
+++ b/src/test/java/paymelah/logic/parser/DeleteDebtCommandParserTest.java
@@ -1,0 +1,114 @@
+package paymelah.logic.parser;
+
+import static paymelah.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static paymelah.logic.commands.CommandTestUtil.INVALID_DEBT_INDEX;
+import static paymelah.logic.commands.CommandTestUtil.INVALID_DEBT_INDEXES;
+import static paymelah.logic.commands.CommandTestUtil.INVALID_DEBT_INDEX_ZERO;
+import static paymelah.logic.commands.CommandTestUtil.VALID_DEBT_INDEX;
+import static paymelah.logic.commands.CommandTestUtil.VALID_DEBT_INDEXES;
+import static paymelah.logic.commands.CommandTestUtil.VALID_DEBT_INDEXES_REPEAT;
+import static paymelah.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static paymelah.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static paymelah.testutil.TypicalIndexes.INDEX_FIRST_DEBT;
+import static paymelah.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static paymelah.testutil.TypicalIndexes.INDEX_SECOND_DEBT;
+import static paymelah.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static paymelah.testutil.TypicalIndexes.INDEX_THIRD_DEBT;
+import static paymelah.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import paymelah.commons.core.index.Index;
+import paymelah.logic.commands.DeleteDebtCommand;
+
+public class DeleteDebtCommandParserTest {
+
+    //private static final String TAG_EMPTY = " " + PREFIX_TAG;
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteDebtCommand.MESSAGE_USAGE);
+
+    private DeleteDebtCommandParser parser = new DeleteDebtCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no person index specified
+        assertParseFailure(parser, VALID_DEBT_INDEX, MESSAGE_INVALID_FORMAT);
+
+        // no debt specified
+        assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);
+
+        // no person and no debts specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        // negative person index
+        assertParseFailure(parser, "-5" + VALID_DEBT_INDEX, MESSAGE_INVALID_FORMAT);
+
+        // zero person index
+        assertParseFailure(parser, "0" + VALID_DEBT_INDEX, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "1 some random string" + VALID_DEBT_INDEX, MESSAGE_INVALID_FORMAT);
+
+        // invalid prefix being parsed as preamble
+        assertParseFailure(parser, "1 i/ string" + VALID_DEBT_INDEX, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, "1" + INVALID_DEBT_INDEX, MESSAGE_INVALID_FORMAT); // non-index
+        assertParseFailure(parser, "1" + INVALID_DEBT_INDEX_ZERO, MESSAGE_INVALID_FORMAT); // zero index
+        assertParseFailure(parser, "1" + INVALID_DEBT_INDEXES, MESSAGE_INVALID_FORMAT); // multiple spacing
+    }
+
+    @Test
+    public void parse_oneDebt_success() {
+        Index targetIndex = INDEX_THIRD_PERSON;
+        String userInput = targetIndex.getOneBased() + VALID_DEBT_INDEX;
+
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT));
+        DeleteDebtCommand expectedCommand = new DeleteDebtCommand(targetIndex, debtIndexSet);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleDebt_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + VALID_DEBT_INDEXES;
+
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT, INDEX_SECOND_DEBT, INDEX_THIRD_DEBT));
+        DeleteDebtCommand expectedCommand = new DeleteDebtCommand(targetIndex, debtIndexSet);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleDebtWithRepeat_success() {
+        Index targetIndex = INDEX_SECOND_PERSON;
+        String userInput = targetIndex.getOneBased() + VALID_DEBT_INDEXES_REPEAT;
+
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT, INDEX_THIRD_DEBT));
+        DeleteDebtCommand expectedCommand = new DeleteDebtCommand(targetIndex, debtIndexSet);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String userInput = targetIndex.getOneBased() + INVALID_DEBT_INDEX + VALID_DEBT_INDEX;
+
+        Set<Index> debtIndexSet = new HashSet<>(List.of(INDEX_FIRST_DEBT));
+        DeleteDebtCommand expectedCommand = new DeleteDebtCommand(targetIndex, debtIndexSet);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/paymelah/logic/parser/DeleteDebtCommandParserTest.java
+++ b/src/test/java/paymelah/logic/parser/DeleteDebtCommandParserTest.java
@@ -111,8 +111,4 @@ public class DeleteDebtCommandParserTest {
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
-<<<<<<< HEAD
-=======
-
->>>>>>> 9b73f9b1146d25c4ff36bc99f9cea7956389111d
 }

--- a/src/test/java/paymelah/testutil/TypicalIndexes.java
+++ b/src/test/java/paymelah/testutil/TypicalIndexes.java
@@ -9,6 +9,8 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST_PERSON = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_PERSON = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_PERSON = Index.fromOneBased(3);
+    public static final Index INDEX_FIFTH_PERSON = Index.fromOneBased(5);
+    public static final Index INDEX_SEVENTH_PERSON = Index.fromOneBased(7);
     public static final Index INDEX_FIRST_DEBT = Index.fromOneBased(1);
     public static final Index INDEX_SECOND_DEBT = Index.fromOneBased(2);
     public static final Index INDEX_THIRD_DEBT = Index.fromOneBased(3);


### PR DESCRIPTION
Other notable changes include changing implementation of DeleteDebtCommand::execute to use ArrayList<Debt> instead of Set<Debt>.