### PR TITLE
Update UGDG for delete debt

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -354,6 +354,28 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
       Use case resumes at step 2.
 
+**UC03: Delete debts**
+
+**MSS**
+
+1.  User requests to list persons
+1.  PayMeLah shows a list of persons
+1.  User requests to delete specific debts from a specific person in the list
+1.  PayMeLah deletes these debts
+
+    Use case ends.
+
+**Extensions**
+
+* 2a. The list is empty.
+
+  Use case ends.
+
+* 3a. The given indexes are invalid.
+
+    * 3a1. PayMeLah shows an error message.
+
+      Use case resumes at step 2.
 
 **UC04: Clear debts**
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -106,6 +106,15 @@ Format: `cleardebts <person index>`
 Example:
 * `cleardebts 3`
 
+### Deleting debts: `deletedebts`
+
+Deletes the debts specified by their index numbers from a person listed in PayMeLah.
+
+Format: `deletedebts <person index> debt/1 3 4`
+
+Example:
+* `deletedebts 2 debt/2 3`
+
 ### Getting the statement
 
 Retrieves a statement of the total sum of debts you are owed.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,7 +110,7 @@ Example:
 
 Deletes the debts specified by their index numbers from a person listed in PayMeLah.
 
-Format: `deletedebts <person index> debt/1 3 4`
+Format: `deletedebts <person index> debt/<debt index...>`
 
 Example:
 * `deletedebts 2 debt/2 3`


### PR DESCRIPTION
Updated DG Use Cases. Note Use Case numbers are currently not in order and should be finalised after most use cases for the features are drafted.

The command prefix for delete debt will be changed to deletedebts from deletedebt. Refactoring will be conducted after the relevant pull-requests are concluded.